### PR TITLE
fix: allow gateways and web3-storage-staging

### DIFF
--- a/packages/images/src/index.js
+++ b/packages/images/src/index.js
@@ -1,5 +1,5 @@
-import { HTTPError } from './errors.js'
-import { parseOptions, parseURL, processImageURL } from './utils.js'
+import { HTTPError } from './response.js'
+import { parseOptions, parseURL, processImageURL } from './utils/index.js'
 
 /**
  * @param {Request} request

--- a/packages/images/src/response.js
+++ b/packages/images/src/response.js
@@ -1,6 +1,20 @@
 /** @typedef {{ code: string }} Coded */
 
-import { JSONResponse } from './utils.js'
+export class JSONResponse extends Response {
+  /**
+   *
+   * @param {unknown} body
+   * @param {ResponseInit} [init]
+   */
+  constructor(body, init = {}) {
+    const headers = {
+      headers: {
+        'content-type': 'application/json;charset=UTF-8',
+      },
+    }
+    super(JSON.stringify(body), { ...init, ...headers })
+  }
+}
 
 export class HTTPError extends Error {
   /**

--- a/packages/images/src/utils/index.js
+++ b/packages/images/src/utils/index.js
@@ -1,20 +1,6 @@
-import { HTTPError } from './errors.js'
-
-export class JSONResponse extends Response {
-  /**
-   *
-   * @param {unknown} body
-   * @param {ResponseInit} [init]
-   */
-  constructor(body, init = {}) {
-    const headers = {
-      headers: {
-        'content-type': 'application/json;charset=UTF-8',
-      },
-    }
-    super(JSON.stringify(body), { ...init, ...headers })
-  }
-}
+import { HTTPError } from '../response.js'
+import { validateImageURL } from './validate-url.js'
+export * from './validate-url.js'
 
 /**
  * Parse the request URL
@@ -33,34 +19,6 @@ export function parseURL(url) {
     }
   }
   HTTPError.throw(`Request URL is invalid.`, 400)
-}
-
-/**
- * Validate the image URL
- *
- * @param {string} hostname
- */
-function validateImageURL(hostname) {
-  const hostnames = [
-    'localhost',
-    'web3.storage',
-    'web3-storage.pages.dev',
-    'nft.storage',
-    'nft-storage-1at.pages.dev',
-  ]
-  // eslint-disable-next-line no-undef
-  const pattern = new URLPattern({
-    protocol: 'http{s}?',
-    hostname: `{*.}?(${hostnames.join('|')})`,
-    pathname: '*.(jpe?g|png|gif|webp)',
-  })
-
-  const out = pattern.exec(hostname)
-  if (out === null) {
-    return false
-  }
-
-  return out
 }
 
 /**

--- a/packages/images/src/utils/validate-url.js
+++ b/packages/images/src/utils/validate-url.js
@@ -1,0 +1,39 @@
+/**
+ * Validate the image URL
+ *
+ * @param {string} hostname
+ */
+export function validateImageURL(hostname) {
+  const hostnames = [
+    'localhost',
+    'web3.storage',
+    'web3-storage.pages.dev',
+    'web3-storage-staging.pages.dev',
+    'nft.storage',
+    'nft-storage-1at.pages.dev',
+  ]
+
+  const pathname = '*.(jpe?g|png|gif|webp)'
+
+  // eslint-disable-next-line no-undef
+  const allowListPattern = new URLPattern({
+    protocol: 'http{s}?',
+    hostname: `{*.}?(${hostnames.join('|')})`,
+    pathname,
+  })
+
+  // eslint-disable-next-line no-undef
+  const gatewayPattern = new URLPattern({
+    protocol: 'http{s}?',
+    hostname: '*.ip(fs|ns).*',
+    pathname: '*.(jpe?g|png|gif|webp)',
+  })
+
+  for (const pattern of [allowListPattern, gatewayPattern]) {
+    const out = pattern.exec(hostname)
+    if (out !== null) {
+      return out
+    }
+  }
+  return false
+}

--- a/packages/images/test/validate-url.test.js
+++ b/packages/images/test/validate-url.test.js
@@ -1,0 +1,33 @@
+import { test } from './helpers/setup.js'
+import { validateImageURL } from '../src/utils/validate-url.js'
+
+test('should pass with allowed domain and path', (t) => {
+  const fixture = [
+    'http://localhost/foo.png',
+    'http://localhost/foo.jpg',
+    'http://localhost/foo.jpeg',
+    'http://localhost/foo.jpeg',
+    'https://web3.storage/foo.jpeg',
+    'https://web3-storage-staging.pages.dev/bar.webp',
+  ]
+  for (const url of fixture) {
+    t.truthy(validateImageURL(url))
+  }
+})
+
+test('should fail if domain or path is UNACCEPTABLE!', (t) => {
+  const fixture = ['https://coolgifs.link/foo.png', 'http://localhost/foo.mpeg']
+  for (const url of fixture) {
+    t.false(validateImageURL(url))
+  }
+})
+
+test('should validate ipfs subdomain gateway', (t) => {
+  t.truthy(validateImageURL('https://foo.ipfs.nftstorage.link/foo.png'))
+  t.false(validateImageURL('https://ipfs.nftstorage.link/foo.png'))
+})
+
+test('should validate ipns subdomain gateway', (t) => {
+  t.truthy(validateImageURL('https://bar.ipns.dweb.link/foo.png'))
+  t.false(validateImageURL('https://ipns.nftstorage.link/foo.png'))
+})


### PR DESCRIPTION
Accept calls from gateways and web3-storage-staging deployment.

Moves things around a little so we can test the util function without "Response is not defined" error

fixes #1

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>