### PR TITLE
fix: some edge cases around _date ordering helper

### DIFF
--- a/packages/utils/src/logging.js
+++ b/packages/utils/src/logging.js
@@ -111,20 +111,17 @@ export class Logging {
    */
   _date() {
     const now = Date.now()
-    if (now === this.currentTs) {
-      const dt = new Date().toISOString()
+    if (now > this.currentTs) {
+      this.currentTs = now
+    } else {
+      // currentTs equal or already ahead
       /**
        * Fake increment the datetime string to order the logs entries
-       * It won't leap seconds but for most cases it will increment by 1 the datetime milliseconds
+       * Unless very busy should usually be only +1ms of the actual datetime
        */
-      const newDt = dt.replace(/\.(\d*)Z/, (s, p1, p2) => {
-        return `.${String(Number(p1) + this.logEventsBatch.length)}Z`
-      })
-      return new Date(newDt).toISOString()
-    } else {
-      this.currentTs = now
-      return new Date().toISOString()
+      this.currentTs += 1
     }
+    return new Date(this.currentTs).toISOString()
   }
 
   /**

--- a/packages/utils/test/logging.test.js
+++ b/packages/utils/test/logging.test.js
@@ -19,6 +19,16 @@ test('should add a log to the batch ', async (t) => {
   t.is(log.logEventsBatch[0].message, 'testing')
 })
 
+test('should always get distinctly ordered times', async (t) => {
+  const log = logging()
+
+  log.log('testing1')
+  log.log('testing2')
+
+  t.is(log.logEventsBatch.length, 2)
+  t.assert(log.logEventsBatch[1].dt > log.logEventsBatch[0].dt)
+})
+
 test('should not log with time', async (t) => {
   const log = logging()
 

--- a/packages/utils/test/logging.test.js
+++ b/packages/utils/test/logging.test.js
@@ -10,7 +10,7 @@ function logging() {
   )
 }
 
-test('should add a log to the batch ', async (t) => {
+test('should add a log to the batch', async (t) => {
   const log = logging()
 
   log.log('testing')


### PR DESCRIPTION
While browsing this repo, I noticed the current code for the `Logging._date()` helper looked somewhat troublesome:

1. if its `dt` string were already at some "hh:mm:ss.999" it would roll **backwards** to `…ss.000` which seemed worse than simply allowing seconds to roll forward
2. the stable `now` value wasn't being taken advantage of and instead new (and potentially-mismatched) timestamps were getting re-created in a few cases
3. seemed somewhat complicated to depend on other code's `logEventsBatch.length` rather than sticking with the more self-contained `currentTs` value

The new implementation should also be a fair bit more efficient since it now does most work numerically rather than involving several back-and-forth string conversions.